### PR TITLE
readme: advantage over GNU `test`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # path-exists-cli [![Build Status](https://travis-ci.org/sindresorhus/path-exists-cli.svg?branch=master)](https://travis-ci.org/sindresorhus/path-exists-cli)
 
-> Check if a path exists
+> Check if a path exists, [cross-platform](https://github.com/sindresorhus/path-exists-cli/issues/1).
 
 
 ## Install


### PR DESCRIPTION
To clarify, `test` from GNU coreutils works fine on Windows and Mac OS
as well; the advantage is just about which programs we can expect to
be installed on systems where this package is used.
